### PR TITLE
Add support for network visualiser when connected to shared instance

### DIFF
--- a/meshchat.py
+++ b/meshchat.py
@@ -1093,21 +1093,22 @@ class ReticulumMeshChat:
             if "transport_id" in interface_stats:
                 interface_stats["transport_id"] = interface_stats["transport_id"].hex()
 
+            # ensure probe_responder is hex as json_response can't serialize bytes
+            if "probe_responder" in interface_stats:
+                interface_stats["probe_responder"] = interface_stats["probe_responder"].hex()
+            
             # ensure ifac_signature is hex as json_response can't serialize bytes
             for interface in interface_stats["interfaces"]:
+                interface["interface_name"] = interface["short_name"]
 
-                # add interface hashes
-                interface_instance = self.find_interface_by_name(interface["name"])
-                if interface_instance is not None:
-                    interface["type"] = type(interface_instance).__name__
-                    interface["hash"] = interface_instance.get_hash().hex()
-                    interface["interface_name"] = interface_instance.name
-                    if hasattr(interface_instance, "parent_interface") and interface_instance.parent_interface is not None:
-                        interface["parent_interface_name"] = str(interface_instance.parent_interface)
-                        interface["parent_interface_hash"] = interface_instance.parent_interface.get_hash().hex()
+                if "parent_interface_name" in interface and interface["parent_interface_name"] != None:
+                    interface["parent_interface_hash"] = interface["parent_interface_hash"].hex()
 
                 if "ifac_signature" in interface and interface["ifac_signature"]:
                     interface["ifac_signature"] = interface["ifac_signature"].hex()
+
+                if "hash" in interface and interface["hash"]:
+                    interface["hash"] = interface["hash"].hex()
 
             return web.json_response({
                 "interface_stats": interface_stats,


### PR DESCRIPTION
This PR adds support for parent/child interface visualization when connected to a shared RNS instance, and removes dependency on manually getting certain interface-specific characteristics such as hash and name, since these were added natively in [RNS 42319a092db0d593e35f07478d1eece907f3bb88](https://github.com/markqvist/Reticulum/commit/42319a092db0d593e35f07478d1eece907f3bb88).

Also fixes a bug where the network visualizer would fail if a probe responder was active on the transport node.