### PR TITLE
Docker: Very minor documentation update

### DIFF
--- a/docs/meshchat_on_docker.md
+++ b/docs/meshchat_on_docker.md
@@ -3,7 +3,7 @@
 A docker image is automatically built by GitHub actions, and can be downloaded from the GitHub container registry.
 
 ```
-docker pull ghcr.io/liamcottle/reticulum-meshchat:master
+docker pull ghcr.io/liamcottle/reticulum-meshchat:latest
 ```
 
 Additionally, an example [docker-compose.yml](../docker-compose.yml) is available.


### PR DESCRIPTION
Use the `latest` tag which is always moved with the latest build. 

The `master` tag used for the initial build is a fallback because it wasn't a tag. In the future when a release is created the image will share the release version (eg: `v1.60.0`) and `latest`.