### PR TITLE
filter out known flags that should not be passed to python. fixes #61

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -99,7 +99,9 @@ function getDefaultReticulumConfigDir() {
 app.whenReady().then(async () => {
 
     // get arguments passed to application, and remove the provided application path
-    const userProvidedArguments = process.argv.slice(1);
+    const ignoredArguments = ["--no-sandbox"];
+    const userProvidedArguments = process.argv.slice(1)
+        .filter(arg => !ignoredArguments.includes(arg));
     const shouldLaunchHeadless = userProvidedArguments.includes("--headless");
 
     if(!shouldLaunchHeadless){


### PR DESCRIPTION
This adds a simple flag filter before passing flags to python, so that we can avoid passing `--no-sandbox`, fixing launching the appimage after being integrated by AppImageLauncher.