### PR TITLE
add `ozone-platform-hint=auto` to known flags

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -99,7 +99,7 @@ function getDefaultReticulumConfigDir() {
 app.whenReady().then(async () => {
 
     // get arguments passed to application, and remove the provided application path
-    const ignoredArguments = ["--no-sandbox"];
+    const ignoredArguments = ["--no-sandbox", "--ozone-platform-hint=auto"];
     const userProvidedArguments = process.argv.slice(1).filter((arg) => !ignoredArguments.includes(arg));
     const shouldLaunchHeadless = userProvidedArguments.includes("--headless");
 


### PR DESCRIPTION
This allows electron to run natively under wayland