### PR TITLE
check if network_id is not None

### DIFF
--- a/meshchat.py
+++ b/meshchat.py
@@ -1726,7 +1726,7 @@ class ReticulumMeshChat:
                 interface_stats["transport_id"] = interface_stats["transport_id"].hex()
 
             # ensure network_id is hex as json_response can't serialize bytes
-            if "network_id" in interface_stats and interface_stats["network_id"]:
+            if "network_id" in interface_stats and interface_stats["network_id"] is not None:
                 interface_stats["network_id"] = interface_stats["network_id"].hex()
 
             # ensure probe_responder is hex as json_response can't serialize bytes

--- a/meshchat.py
+++ b/meshchat.py
@@ -1726,7 +1726,7 @@ class ReticulumMeshChat:
                 interface_stats["transport_id"] = interface_stats["transport_id"].hex()
 
             # ensure network_id is hex as json_response can't serialize bytes
-            if "network_id" in interface_stats:
+            if "network_id" in interface_stats and interface_stats["network_id"]:
                 interface_stats["network_id"] = interface_stats["network_id"].hex()
 
             # ensure probe_responder is hex as json_response can't serialize bytes


### PR DESCRIPTION
Sometimes the `interface_stats` has the `network_id` field but it is `None`. In such case the MeshChat cannot get interface statistics and all interfaces shows as `disconnected`

```
meshchat-1  |   File "/opt/reticulum-meshchat/meshchat.py", line 1730, in index
meshchat-1  |     interface_stats["network_id"] = interface_stats["network_id"].hex()
meshchat-1  |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
meshchat-1  | AttributeError: 'NoneType' object has no attribute 'hex'
```

This patch checks if `network_id` contains somthing meaningfull.