### PR TITLE
Update RNS to 1.3.1 and LXMF to 0.9.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp>=3.13.3
 cx_freeze>=7.0.0
-lxmf>=0.9.6
+lxmf>=0.9.9
 peewee>=3.18.1,<4.0.0
-rns>=1.2.4
+rns>=1.3.1
 websockets>=16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp>=3.13.3
 cx_freeze>=7.0.0
-lxmf>=0.9.3
+lxmf>=0.9.6
 peewee>=3.18.1,<4.0.0
-rns>=1.1.4
+rns>=1.2.4
 websockets>=16.0


### PR DESCRIPTION
RNS 1.1.9 contains critical security fix: https://github.com/markqvist/Reticulum/releases/tag/1.1.9