### PR TITLE
Build native Apple Silicon (arm64) mac releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,12 @@ jobs:
           artifacts: "dist/*-win-installer.exe,dist/*-win-portable.exe"
 
   build_mac:
-    runs-on: macos-13
+    strategy:
+      matrix:
+        # macos-13 is an Intel (x64) runner, macos-14 is an Apple Silicon (arm64) runner.
+        # cx_Freeze can only build for the host architecture, so each arch needs its own runner.
+        os: [macos-13, macos-14]
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: write
     steps:
@@ -80,7 +85,7 @@ jobs:
           replacesArtifacts: true
           omitDraftDuringUpdate: true
           omitNameDuringUpdate: true
-          artifacts: "dist/*-mac.dmg"
+          artifacts: "dist/*-mac-*.dmg"
 
   build_linux:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "mac": {
       "target": "dmg",
       "identity": null,
-      "artifactName": "ReticulumMeshChat-v${version}-${os}.${ext}",
+      "artifactName": "ReticulumMeshChat-v${version}-${os}-${arch}.${ext}",
       "extendInfo": {
         "NSMicrophoneUsageDescription": "Microphone access is only needed for Audio Calls",
         "com.apple.security.device.audio-input": true


### PR DESCRIPTION
## What

The mac `.dmg` releases are currently built only on `macos-13`, which is an Intel (x64) runner — so on Apple Silicon Macs the app runs under Rosetta 2. Since cx_Freeze can only build for the host architecture, this PR adds a build matrix so the release workflow builds on both `macos-13` (Intel) and `macos-14` (Apple Silicon), producing a native dmg for each.

## Changes

- `.github/workflows/build.yml`: `build_mac` now runs as a matrix over `[macos-13, macos-14]`, and the release artifact glob is widened to `dist/*-mac-*.dmg`
- `package.json`: mac `artifactName` now includes `${arch}` (e.g. `ReticulumMeshChat-v2.3.0-mac-arm64.dmg`) so the two dmgs don't overwrite each other in the release

No application code changes were needed — everything is already arch-agnostic.

## Testing

Build-tested natively on an M2 Mac: `npm run dist` produces a working arm64 dmg; the Electron shell and the cx_Freeze backend both run natively (verified with `lipo -archs` and `sysctl.proc_translated = 0`), and the app serves the UI normally on port 9337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016eEGG2yXnGbVLHc6V2ubtp