### PR TITLE
Fix rejected messages reappearing after deleting conversation history

### DIFF
--- a/meshchat.py
+++ b/meshchat.py
@@ -3031,10 +3031,11 @@ class ReticulumMeshChat:
             has_delivered = lxmf_message.state == LXMF.LXMessage.DELIVERED
             has_propagated = lxmf_message.state == LXMF.LXMessage.SENT and lxmf_message.method == LXMF.LXMessage.PROPAGATED
             has_failed = lxmf_message.state == LXMF.LXMessage.FAILED
+            has_rejected = lxmf_message.state == LXMF.LXMessage.REJECTED
             is_cancelled = lxmf_message.state == LXMF.LXMessage.CANCELLED
 
             # check if we should stop updating
-            if has_delivered or has_propagated or has_failed or is_cancelled:
+            if has_delivered or has_propagated or has_failed or has_rejected or is_cancelled:
                 should_update_message = False
 
     # handle an announce received from reticulum, for an audio call address


### PR DESCRIPTION
Deleting a conversation's message history did not stick for rejected messages. Leave the page, come back, and the rejected message is back.

Root cause: handle_lxmf_message_progress upserts the message to the database every second until it hits a terminal state, but REJECTED was not in the stop conditions. A rejected message never stopped the loop, so it re-inserted itself into the database one second after the delete.

Fix: add REJECTED to the stop conditions. The loop does one final upsert so the UI still shows the rejected state, then stops.

To reproduce: send an attachment that exceeds the recipient's delivery limit so it gets rejected, delete the conversation history, reload the page. Before this fix the message comes back.