### PR TITLE
Fix silent message loss in frozen builds during stamp validation

### DIFF
--- a/meshchat.py
+++ b/meshchat.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python
 
+import multiprocessing
+
+# required for multiprocessing to work in frozen builds (e.g. lxmf stamp validation worker pools)
+# without it, worker processes re-run the app instead of bootstrapping, which hangs the pool
+# must run before other imports so worker processes exit into their bootstrap immediately
+multiprocessing.freeze_support()
+
 import argparse
 import io
 import json


### PR DESCRIPTION
LXMF validates propagation stamps in a multiprocessing worker pool (LXStamper.validate_pn_stamps). In frozen builds (cx_Freeze) the worker processes crash on circular imports and hang the pool forever. Propagation transfers complete at the link level before validation runs, so senders see success while recipients silently lose the whole batch. Any packaged build running a propagation node or receiving large propagation syncs is affected.

Fix is one line: call multiprocessing.freeze_support() before other imports, the documented cx_Freeze requirement. Worker processes then bootstrap correctly instead of re-running the app.

Reproduced with a standalone cx_Freeze test app calling validate_pn_stamps with 300 entries: without the call it hangs indefinitely with repeated 'partially initialized module RNS' errors from the workers, with it the pool completes cleanly. Running from source is unaffected, which is why this survives normal testing.